### PR TITLE
Upgrade to use `<stdlib.h>` to replace `<malloc.h>`

### DIFF
--- a/bm_utils.c
+++ b/bm_utils.c
@@ -68,7 +68,7 @@
 #include <ctype.h>
 #include <math.h>
 #ifndef _POSIX_SOURCE
-#include <malloc.h>
+#include <stdlib.h>
 #endif /* POSIX_SOURCE */
 #include <fcntl.h>
 #include <sys/types.h>

--- a/varsub.c
+++ b/varsub.c
@@ -41,7 +41,7 @@
 */
 #include <stdio.h>
 #ifndef _POSIX_SOURCE
-#include <malloc.h>
+#include <stdlib.h>
 #endif /* POSIX_SOURCE */
 #if (defined(_POSIX_)||!defined(WIN32))
 #include <unistd.h>


### PR DESCRIPTION
### The Rationales

Coses https://github.com/databricks/tpch-dbgen/issues/3

In MacOS enviroment, `make` failed due to no `malloc.h`.

The `malloc.h` is deprecated and should not be used. It contains some non-standard functions too. If we need use `malloc()`, then include `stdlib.h`. Not even the C89 standard mentions `malloc.h`.