### PR TITLE
Switch from malloc.h to stdlib.h for POSIX compliance

### DIFF
--- a/bm_utils.c
+++ b/bm_utils.c
@@ -68,7 +68,8 @@
 #include <ctype.h>
 #include <math.h>
 #ifndef _POSIX_SOURCE
-#include <malloc.h>
+//#include <malloc.h>
+#include<stdlib.h>
 #endif /* POSIX_SOURCE */
 #include <fcntl.h>
 #include <sys/types.h>

--- a/varsub.c
+++ b/varsub.c
@@ -41,7 +41,7 @@
 */
 #include <stdio.h>
 #ifndef _POSIX_SOURCE
-#include <malloc.h>
+#include<stdlib.h>
 #endif /* POSIX_SOURCE */
 #if (defined(_POSIX_)||!defined(WIN32))
 #include <unistd.h>


### PR DESCRIPTION
Replaced instances of malloc.h with stdlib.h to ensure better POSIX compliance and portability of the code. This change impacts bm_utils.c and varsub.c files.